### PR TITLE
Fix riseup mail

### DIFF
--- a/rules/riseup-mail.xml
+++ b/rules/riseup-mail.xml
@@ -1,4 +1,6 @@
 <ruleset name="Riseup Mail Onion">
 	<target host="mail.riseup.net" />
-	<rule from="^https?://mail\.riseup\.net/" to="http://zsolxunfmbfuq7wf.onion/" />
+	<target host="fruiteater.riseup.net" />
+	<target host="fulvetta.riseup.net" />
+	<rule from="^https?://(mail|fruiteater|fulvetta)\.riseup\.net/" to="http://zsolxunfmbfuq7wf.onion/" />
 </ruleset>


### PR DESCRIPTION
Currently, if you try to login, you will be redirected to one of the two clearnet subdomains
